### PR TITLE
added check for supported CF version

### DIFF
--- a/cmdline-security-analyzer.cfm
+++ b/cmdline-security-analyzer.cfm
@@ -119,6 +119,10 @@
 		// convert JSON to ColdFusion variables
 		scanResult = deserializeJSON(jsonString, true);
 		
+		if (structKeyExists(scanresult,"errormessage") && findnocase("Security Code Analyzer is not available in this edition of the ColdFusion Server",scanresult.errormessage)){
+			throw(type="wrongVersion", message="ERROR: wrong CF edition", detail="#scanresult.errormessage#", errorCode=-2); 
+		}
+
 		// populate id needed for subsequent commands
 		id = scanResult["id"];
 


### PR DESCRIPTION
Must be CF Enterprise or Trial. Standard and Developer editions are not supported (CF will reject requests from this tool, reporting this as an error.)

Without this check, the next line of code (referring to scanResult["id"] fails, because the scanresult error does not include that id result.